### PR TITLE
Add minimal PostgreSQL smoke test to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,4 +12,8 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile
+          load: true
+          tags: pg-on-zfs:test
           push: false
+      - run: docker run -d --name pgtest --privileged pg-on-zfs:test
+      - run: ./test.sh pgtest

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -euo pipefail
+container="${1:-pgtest}"
+# wait for postgres
+until docker exec "$container" pg_isready -U postgres >/dev/null 2>&1; do
+  sleep 1
+done
+# check connection to maindb
+docker exec "$container" psql -U postgres -d maindb -c 'SELECT 1;'
+# clone database
+docker exec "$container" psql -U postgres -c "CREATE DATABASE clonedb TEMPLATE maindb;"
+# connect to cloned database
+docker exec "$container" psql -U postgres -d clonedb -c 'SELECT 1;'
+# drop cloned database
+docker exec "$container" psql -U postgres -c "DROP DATABASE clonedb;"


### PR DESCRIPTION
## Summary
- add a minimal bash test to connect, clone, and drop a PostgreSQL database
- execute the container and run the test script in CI

## Testing
- `make lint`
- `docker build -t pg-on-zfs:test -f docker/Dockerfile .` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68b353a00650832fb6a70843b2e07ffc