### PR TITLE
Add CI test for PostgreSQL ZFS image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,3 +13,10 @@ jobs:
           context: .
           file: docker/Dockerfile
           push: false
+          tags: pg-on-zfs:test
+      - name: Run container tests
+        run: |
+          mkdir -p hostdata
+          docker run -d --name pg-test --privileged -v ${GITHUB_WORKSPACE}/hostdata:/hostdata pg-on-zfs:test
+          ./test.sh pg-test
+          docker rm -f pg-test

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+set -e
+
+container="$1"
+if [ -z "$container" ]; then
+  echo "usage: $0 <container>" >&2
+  exit 1
+fi
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "docker is required" >&2
+  exit 1
+fi
+
+until docker exec "$container" pg_isready -U postgres >/dev/null 2>&1; do
+  sleep 1
+done
+
+docker exec "$container" su - postgres -c "psql -d maindb -c 'SELECT 1'"
+
+docker exec "$container" su - postgres -c "createdb -T maindb clonedb"
+
+docker exec "$container" su - postgres -c "psql -d clonedb -c 'SELECT 1'"
+
+docker exec "$container" su - postgres -c "dropdb clonedb"


### PR DESCRIPTION
## Summary
- build and run the Docker image in CI
- add a minimal test script that verifies PostgreSQL can clone and drop a database

## Testing
- `make lint`
- `./test.sh pg-test` *(fails: docker is required)*

------
https://chatgpt.com/codex/tasks/task_e_68b353a00650832fb6a70843b2e07ffc