### PR TITLE
Handle Postgres startup failure in tests

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 set -e
+
+# location of PostgreSQL binaries
+PG_BINDIR=$(pg_config --bindir)
+
 if [ ! -e /hostdata/pgpool.img ]; then
   truncate -s ${ZPOOL_SIZE:-60G} /hostdata/pgpool.img
   zpool create -f -o ashift=12 pgpool /hostdata/pgpool.img
@@ -8,11 +12,13 @@ if [ ! -e /hostdata/pgpool.img ]; then
 else
   zpool import -d /hostdata pgpool
 fi
+
 if [ ! -s /pgpool/pgdata/PG_VERSION ]; then
-  su - postgres -c "initdb -D /pgpool/pgdata"
-  su - postgres -c "pg_ctl -D /pgpool/pgdata -w start"
-  su - postgres -c "createdb -D pg_default maindb"
-  su - postgres -c "pg_ctl -D /pgpool/pgdata stop"
+  su postgres -c "$PG_BINDIR/initdb -D /pgpool/pgdata"
+  su postgres -c "$PG_BINDIR/pg_ctl -D /pgpool/pgdata -w start"
+  su postgres -c "$PG_BINDIR/createdb -D pg_default maindb"
+  su postgres -c "$PG_BINDIR/pg_ctl -D /pgpool/pgdata stop"
 fi
-su - postgres -c "python3 /pgbranchd/main.py &"
-exec su - postgres -c "postgres -D /pgpool/pgdata"
+
+su postgres -c "python3 /pgbranchd/main.py &"
+exec su postgres -c "$PG_BINDIR/postgres -D /pgpool/pgdata"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -14,11 +14,11 @@ else
 fi
 
 if [ ! -s /pgpool/pgdata/PG_VERSION ]; then
-  su postgres -c "$PG_BINDIR/initdb -D /pgpool/pgdata"
-  su postgres -c "$PG_BINDIR/pg_ctl -D /pgpool/pgdata -w start"
-  su postgres -c "$PG_BINDIR/createdb -D pg_default maindb"
-  su postgres -c "$PG_BINDIR/pg_ctl -D /pgpool/pgdata stop"
+  su - postgres -c "$PG_BINDIR/initdb -D /pgpool/pgdata"
+  su - postgres -c "$PG_BINDIR/pg_ctl -D /pgpool/pgdata -w start"
+  su - postgres -c "$PG_BINDIR/createdb -D pg_default maindb"
+  su - postgres -c "$PG_BINDIR/pg_ctl -D /pgpool/pgdata stop"
 fi
 
-su postgres -c "python3 /pgbranchd/main.py &"
-exec su postgres -c "$PG_BINDIR/postgres -D /pgpool/pgdata"
+su - postgres -c "python3 /pgbranchd/main.py &"
+exec su - postgres -c "$PG_BINDIR/postgres -D /pgpool/pgdata"

--- a/test.sh
+++ b/test.sh
@@ -1,10 +1,30 @@
 #!/bin/bash
+# Strict mode
 set -euo pipefail
+
 container="${1:-pgtest}"
-# wait for postgres
+timeout_seconds=30
+start=$(date +%s)
+
+# Print container logs on any error for easier debugging
+trap 'echo "\n--- docker logs for $container ---"; docker logs "$container" || true' ERR
+
+# wait for postgres with timeout
 until docker exec "$container" pg_isready -U postgres >/dev/null 2>&1; do
+  if ! docker ps --format '{{.Names}}' | grep -q "^${container}$"; then
+    echo "Container $container is not running"
+    exit 1
+  fi
+  elapsed=$(( \
+    $(date +%s) - start \
+  ))
+  if [ "$elapsed" -ge "$timeout_seconds" ]; then
+    echo "Timed out waiting for postgres after ${timeout_seconds}s"
+    exit 1
+  fi
   sleep 1
 done
+echo "Postgres is ready"
 # check connection to maindb
 docker exec "$container" psql -U postgres -d maindb -c 'SELECT 1;'
 # clone database

--- a/test.sh
+++ b/test.sh
@@ -13,6 +13,7 @@ trap 'echo "\n--- docker logs for $container ---"; docker logs "$container" || t
 until docker exec "$container" pg_isready -U postgres >/dev/null 2>&1; do
   if ! docker ps --format '{{.Names}}' | grep -q "^${container}$"; then
     echo "Container $container is not running"
+    docker logs "$container" || true
     exit 1
   fi
   elapsed=$(( \
@@ -20,6 +21,7 @@ until docker exec "$container" pg_isready -U postgres >/dev/null 2>&1; do
   ))
   if [ "$elapsed" -ge "$timeout_seconds" ]; then
     echo "Timed out waiting for postgres after ${timeout_seconds}s"
+    docker logs "$container" || true
     exit 1
   fi
   sleep 1


### PR DESCRIPTION
## Summary
- add timeout and log dumping to `test.sh` to avoid hanging when Postgres isn't reachable
- resolve missing PostgreSQL binary paths in `docker/entrypoint.sh`

## Testing
- `bash -n test.sh`
- `sh -n docker/entrypoint.sh`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b3776e2064832fb6e0de2987f75bb4