### PR TITLE
Add PostgreSQL startup timeout to test script

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -1,9 +1,22 @@
 #!/bin/bash
 set -euo pipefail
 container="${1:-pgtest}"
-# wait for postgres
-until docker exec "$container" pg_isready -U postgres >/dev/null 2>&1; do
+# wait for postgres (timeout after 30s)
+timeout=30
+while ! docker exec "$container" pg_isready -U postgres >/dev/null 2>&1; do
+  # if container has stopped exit early with logs
+  if ! docker ps --format '{{.Names}}' | grep -q "^$container$"; then
+    echo "Container $container is not running" >&2
+    docker logs "$container" || true
+    exit 1
+  fi
   sleep 1
+  timeout=$((timeout - 1))
+  if [ "$timeout" -le 0 ]; then
+    echo "PostgreSQL did not become ready within 30 seconds" >&2
+    docker logs "$container" || true
+    exit 1
+  fi
 done
 # check connection to maindb
 docker exec "$container" psql -U postgres -d maindb -c 'SELECT 1;'


### PR DESCRIPTION
## Summary
- Avoid indefinite waits in `test.sh` by timing out after 30s if PostgreSQL is unreachable
- Show container logs when startup fails to aid debugging

## Testing
- `bash -n test.sh`
- `make lint`
- `sudo service postgresql start`
- `pg_isready`


------
https://chatgpt.com/codex/tasks/task_e_68b3776e2064832fb6e0de2987f75bb4