### PR TITLE
Use zfs-fuse fallback and verify zfs availability

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:24.04
-RUN apt-get update && apt-get install -y postgresql zfsutils-linux libpq-dev netcat-openbsd python3
+RUN apt-get update && apt-get install -y postgresql zfs-fuse libpq-dev netcat-openbsd python3
 COPY docker/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 COPY cmd/pgbranchd/ /pgbranchd

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,18 +1,51 @@
 #!/bin/sh
 set -e
+
+# Ensure a ZFS implementation is available.  This script prefers the kernel
+# module but falls back to the userspace fuse daemon if necessary.  The
+# container must exit immediately if neither is usable.
+if ! command -v zpool >/dev/null 2>&1; then
+  echo "zpool command not found" >&2
+  exit 1
+fi
+
+# Start zfs-fuse if the kernel module is missing.
+if ! zpool list >/dev/null 2>&1; then
+  if command -v zfs-fuse >/dev/null 2>&1; then
+    zfs-fuse >/dev/null 2>&1 &
+    # give the daemon a moment to start
+    sleep 1
+  fi
+  if ! zpool list >/dev/null 2>&1; then
+    echo "ZFS is not available" >&2
+    exit 1
+  fi
+fi
+
 if [ ! -e /hostdata/pgpool.img ]; then
-  truncate -s ${ZPOOL_SIZE:-60G} /hostdata/pgpool.img
-  zpool create -f -o ashift=12 pgpool /hostdata/pgpool.img
-  zfs create -o mountpoint=/pgpool/pgdata pgpool/pgdata
+  truncate -s "${ZPOOL_SIZE:-60G}" /hostdata/pgpool.img
+  if ! zpool create -f -o ashift=12 pgpool /hostdata/pgpool.img; then
+    echo "failed to create zpool" >&2
+    exit 1
+  fi
+  if ! zfs create -o mountpoint=/pgpool/pgdata pgpool/pgdata; then
+    echo "failed to create ZFS dataset" >&2
+    exit 1
+  fi
   chown -R postgres:postgres /pgpool
 else
-  zpool import -d /hostdata pgpool
+  if ! zpool import -d /hostdata pgpool; then
+    echo "failed to import zpool" >&2
+    exit 1
+  fi
 fi
+
 if [ ! -s /pgpool/pgdata/PG_VERSION ]; then
   su - postgres -c "initdb -D /pgpool/pgdata"
   su - postgres -c "pg_ctl -D /pgpool/pgdata -w start"
   su - postgres -c "createdb -D pg_default maindb"
   su - postgres -c "pg_ctl -D /pgpool/pgdata stop"
 fi
+
 su - postgres -c "python3 /pgbranchd/main.py &"
 exec su - postgres -c "postgres -D /pgpool/pgdata"


### PR DESCRIPTION
## Summary
- ensure container starts zfs-fuse when kernel module is missing and exits if ZFS unavailable
- create and import zpool safely with explicit error handling
- build image with zfs-fuse instead of zfsutils-linux

## Testing
- `./test.sh` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_68b389a1fb44832f924cd91838ff7638